### PR TITLE
Enable script evaluation based on data-eval-js="true"

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,15 @@ To only load certain fragments dependning on media queries, use the `data-fragme
 <div data-fragment="fragment.html" data-fragment-media="(max-width: 250px)"></div>
 ```
 
+### Script Execution
+
+One may want to have scripts on any of the imported sections evaluated after an import. By default this is turned off
+but by setting `data-eval-js` to `true`, scripts on the imported fragment will be executed. This execution will happen on the final html after any templating and interpolation steps.
+
+```html
+<div data-fragment="fragment.html" data-eval-js="true"></div>
+```
+
 ## Configuring fragment.js
 
 ### Overriding

--- a/fragment.js
+++ b/fragment.js
@@ -106,7 +106,7 @@
     var html_url = element.getAttribute('data-'+fragment.html);
     var json_url = element.getAttribute('data-'+fragment.json);
     var media = element.getAttribute('data-fragment-media');
-    var js_eval = element.getAttribute('data-eval-js'); //must eval script elements?
+    var js_eval = ('' + element.getAttribute('data-eval-js') ).toLowerCase(); //must eval script elements?
 
     // Don't load anything if the media query doesn't match
     if ( media && win.matchMedia && !win.matchMedia(media).matches ) return;
@@ -123,7 +123,7 @@
       load(html_url, function(html) {
         load(json_url, function(json) {
           resource_loaded(render_template.bind(this, element, html, json));
-          if(js_eval){
+          if(js_eval == 'true'){
             evalJs(element);
           }
         });
@@ -132,7 +132,7 @@
     else if (fragment_type.html) {
       load(html_url, function(html) {
         resource_loaded(render_html.bind(this, element, html));
-        if(js_eval){
+        if(js_eval == 'true'){
           evalJs(element);
         }
       });
@@ -140,7 +140,7 @@
     else if (fragment_type.json) {
       load(json_url, function(json) {
         resource_loaded(render_json.bind(this, element, json));
-        if(js_eval){
+        if(js_eval == 'true'){
           evalJs(element);
         }
       });

--- a/fragment.js
+++ b/fragment.js
@@ -52,6 +52,14 @@
     doc.getElementsByTagName('head')[0].appendChild(script);
   };
 
+  var evalJs = function(element){
+    //Evaluate found script tags
+    var scripts = element.getElementsByTagName('script');
+    for (var idx=0; idx < scripts.length; idx++){
+      eval(scripts[idx].text);
+    }    
+  }
+
   var load = function(url, callback) {
     // We'll need something that can easily parse urls
     var url_parser = doc.createElement('a');
@@ -98,6 +106,7 @@
     var html_url = element.getAttribute('data-'+fragment.html);
     var json_url = element.getAttribute('data-'+fragment.json);
     var media = element.getAttribute('data-fragment-media');
+    var js_eval = element.getAttribute('data-eval-js'); //must eval script elements?
 
     // Don't load anything if the media query doesn't match
     if ( media && win.matchMedia && !win.matchMedia(media).matches ) return;
@@ -114,17 +123,26 @@
       load(html_url, function(html) {
         load(json_url, function(json) {
           resource_loaded(render_template.bind(this, element, html, json));
+          if(js_eval){
+            evalJs(element);
+          }
         });
       });
     }
     else if (fragment_type.html) {
       load(html_url, function(html) {
         resource_loaded(render_html.bind(this, element, html));
+        if(js_eval){
+          evalJs(element);
+        }
       });
     }
     else if (fragment_type.json) {
       load(json_url, function(json) {
         resource_loaded(render_json.bind(this, element, json));
+        if(js_eval){
+          evalJs(element);
+        }
       });
     }
   };


### PR DESCRIPTION
Under some circumstances it is useful to be able to have scripts in the fragment evaluated after being imported into the main html. This allows for that.
