### PR TITLE
Fix issue with JSON.parse trying to parse a bunch of empty spaces.

### DIFF
--- a/fragment.js
+++ b/fragment.js
@@ -79,7 +79,7 @@
     // If the innerHTML is nonempty: the context is interpreted as the
     // combination of the JSONified innerHTML and the existing context.
     // The JSONified innerHTML has a higher precedence over the existing context.
-    if (element.innerHTML != "") {
+    if (element.innerHTML.trim() != "") {
       context = extend(JSON.parse(element.innerHTML), context);
     }
 


### PR DESCRIPTION
The following html snippet doest not work with fragment because of the inner empty spaces.

```
<div class="container" data-fragment="views/about.html">
                </div>
```

`trim()` added to avoid this case.
